### PR TITLE
Improve configurability so that Storm can use an external Zookeeper

### DIFF
--- a/src/storm/Chart.yaml
+++ b/src/storm/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 name: storm
 sources:
 - https://github.com/apache/storm
-version: 1.0.5
+version: 1.0.6
 dependencies:
 - name: zookeeper
   version: ~2.1.0

--- a/src/storm/templates/configmap.yaml
+++ b/src/storm/templates/configmap.yaml
@@ -9,13 +9,10 @@ metadata:
 data:
   storm.yaml: |-
     ########### These MUST be filled in for a storm configuration
-    storm.zookeeper.servers:
-      {{- range until (int .Values.zookeeper.replicaCount) }}
-      {{- $target := printf "%s-%d.%s-headless" (include "storm.zookeeper.fullname" $) . (include "storm.zookeeper.fullname" $) }}
-        - {{ $target }}
-      {{- end }}
+    storm.zookeeper.servers: 
+      {{- template "storm.zookeeper.configmap.servers" . }}
     nimbus.seeds:
-        - {{ template "storm.nimbus.fullname" . }}
+      - {{ template "storm.nimbus.fullname" . }}
     storm.local.hostname: {{ template "storm.nimbus.fullname" . }}
     storm.log4j2.conf.dir: "/log4j2"
 
@@ -31,13 +28,10 @@ metadata:
 data:
   storm.yaml: |-
     ########### These MUST be filled in for a storm configuration
-    storm.zookeeper.servers:
-      {{- range until (int .Values.zookeeper.replicaCount) }}
-      {{- $target := printf "%s-%d.%s-headless" (include "storm.zookeeper.fullname" $) . (include "storm.zookeeper.fullname" $) }}
-        - {{ $target }}
-      {{- end }}
+    storm.zookeeper.servers: 
+    {{- template "storm.zookeeper.configmap.servers" . }}
     nimbus.seeds:
-        - {{ template "storm.nimbus.fullname" . }}
+      - {{ template "storm.nimbus.fullname" . }}
     storm.local.hostname: {{ template "storm.supervisor.fullname" . }}
     storm.log4j2.conf.dir: "/log4j2"
 
@@ -69,12 +63,9 @@ metadata:
 data:
   storm.yaml: |-
     ########### These MUST be filled in for a storm configuration
-    storm.zookeeper.servers:
-      {{- range until (int .Values.zookeeper.replicaCount) }}
-      {{- $target := printf "%s-%d.%s-headless" (include "storm.zookeeper.fullname" $) . (include "storm.zookeeper.fullname" $) }}
-        - {{ $target }}
-      {{- end }}
+    storm.zookeeper.servers: 
+      {{- template "storm.zookeeper.configmap.servers" . }}
     nimbus.seeds:
-        - {{ template "storm.nimbus.fullname" . }}
+      - {{ template "storm.nimbus.fullname" . }}
     storm.local.hostname: {{ template "storm.ui.fullname" . }}
     storm.log4j2.conf.dir: "/log4j2"

--- a/src/storm/templates/nimbus-deployment.yaml
+++ b/src/storm/templates/nimbus-deployment.yaml
@@ -22,12 +22,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       initContainers:
-      {{- range until (int .Values.zookeeper.replicaCount) }}
-      {{- $target := printf "%s-%d.%s-headless" (include "storm.zookeeper.fullname" $) . (include "storm.zookeeper.fullname" $) }}
-      - name: init-zookeeper-{{ . }}
-        image: busybox
-        command: ["sh", "-c", "until nc -w10 {{ $target }} 2181 </dev/null; do echo waiting for {{ $target }}; sleep 10; done"]
-      {{- end }}
+      {{- template "storm.nimbus.zookeeper.initContiners" . }}
       containers:
       - name: {{ .Values.nimbus.service.name }}
         image: "{{ .Values.nimbus.image.repository }}:{{ .Values.nimbus.image.tag }}"

--- a/src/storm/values.yaml
+++ b/src/storm/values.yaml
@@ -53,7 +53,17 @@ ui:
 
 zookeeper:
   enabled: true
-  service:
-    name: zookeeper
-  stormName: storm
   replicaCount: 3
+  servers: 
+  #  - example.external.zookeeper1
+  #  - example.external.zookeeper2
+  service:
+    ports:
+      client:
+        port: 2181
+  # TODO: fix upstream zookeeper chart before port is truly configurable
+  # ports:
+  #   client:
+  #     containerPort: 2181
+  # env:
+  #   ZOO_PORT: 2181 


### PR DESCRIPTION
A few things here:

* Made the Zookeeper fullname work like it should
* Now allow external Zookeepers to work
* Moved some boilerplate code from `configmap.yaml` and `nimbus-deployment.yaml` to `_helpers.yaml`
* Started to make port configurable, too, until I decided that the upstream Zookeeper chart needed fixing before this is possible
* Got rid of my override for `zookeeper.fullname` and the `.Values.stormName` that went with it.  

I tested a bunch of scenarios:

* overriding the Zookeeper name with `nameOverride` and `fullnameOverride`
* using the internal Zookeeper from the subchart or using an external Zookeeper (both with DNS and IP values)

I tested changing the port out, too, but there are environment variables in the Zookeeper chart that aren't templated yet and I could see that the client port value was not updating throughout the Zookeeper subchart.  I left the work as-is for the moment until we can fix up the Zookeeper chart we're using (or perhaps switch to Bitnami's which looks a bit better).  I can remove the breadcrumbs in `values.yaml` from this PR if we think it's confusing.  I'd like to leave the work in `_helpers.yaml` regarding port, though.

Note: `storm.zookeeper.fullname` now defaults to a hardcoded "zookeeper".  this is because the Zookeeper subchart defaults to the `.Chart.name` which isn't anything we can access from the parent chart (correct me if I'm mistaken).  Previously, we were defaulting to `.Values.zookeeper.service.name` and this choice works fine if everything simply remains 'zookeeper'.  However, it suggests that we can change it in `values.yaml`, which was not true.  We can change `.Values.zookeeper.service.name` all we want, but the Zookeeper subchart doesn't use that value when assigning its fullname, so it was misleading.  

This could be something we suggest to fix upstream if we really think it's important to do, but it seems unnecessary since we still have two mechanisms of overriding the fullname: `fullnameOverride` and `nameOverride`.  I thought hardcoding "zookeeper" in this instance was fine since it's extremely unlikely that the name of the Zookeeper subchart is going to change from "zookeeper" and at least we aren't suggesting that you can change this value so people won't shoot themselves in the foot.