### PR TITLE
Create a PR when a Armada releases a new version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI for Charts
+
+on:
+  push:
+    branches: 
+      - circleci* 
+
+jobs:
+  createArmadaPR:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create Armada Pull Request
+        id: capr
+        run: |
+          RELEASE_TAG=`git branch --show-current | sed 's/circleci-armada_//'`
+          hub pull-request -m "Update Armada Chart to $RELEASE_TAG"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The only thing this GH action does currently is to create a new PR in the charts repository when a new version of Armada is cut via CircleCI.  

CircleCI will create a branch named `circleci-armada_*` and push it to this charts repository.  When this action sees any branch with a prefix `circleci`, it will run the `createArmadaPR` job and create a new PR for a human to review.