### PR TITLE
Storm chart improvements

### DIFF
--- a/src/storm/templates/NOTES.txt
+++ b/src/storm/templates/NOTES.txt
@@ -9,7 +9,6 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "storm.ui.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.ui.service.externalPort }}
 {{- else if contains "ClusterIP" .Values.ui.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "storm.ui.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.ui.service.port }} -n {{ .Release.Namespace }}
+  kubectl port-forward svc/{{ template "storm.ui.fullname" . }} 8080:{{ .Values.ui.service.port }} -n {{ .Release.Namespace }}
 {{- end }}

--- a/src/storm/templates/_helpers.tpl
+++ b/src/storm/templates/_helpers.tpl
@@ -88,7 +88,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "storm.zookeeper.port" -}}
-{{- ternary $.Values.zookeeper.service.ports.client.port (default 2181 $.Values.zookeeper.port) $.Values.zookeeper.enabled -}}
+{{- ternary .Values.zookeeper.service.ports.client.port (default 2181 .Values.zookeeper.port) .Values.zookeeper.enabled -}}
 {{- end -}}
 
 {{- define "storm.zookeeper.config" -}}

--- a/src/storm/templates/_helpers.tpl
+++ b/src/storm/templates/_helpers.tpl
@@ -83,39 +83,29 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{- define "storm.zookeeper.client.port" -}}
-{{- default 2181 .Values.zookeeper.service.ports.client.port -}}
-{{- end -}}
-
 {{- define "storm.logging.name" -}}
 {{- printf "%s-logging" (include "storm.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "storm.zookeeper.configmap.servers" -}}
-{{- if .Values.zookeeper.enabled -}}
-{{ printf "[%s]" (include "storm.zookeeper.fullname" $) }}
-{{- else -}}
+{{- define "storm.zookeeper.port" -}}
+{{- ternary $.Values.zookeeper.service.ports.client.port (default 2181 $.Values.zookeeper.port) $.Values.zookeeper.enabled -}}
+{{- end -}}
+
+{{- define "storm.zookeeper.config" -}}
+{{- $servers := list (include "storm.zookeeper.fullname" .) -}}
+{{- if not .Values.zookeeper.enabled -}}
 {{- $nullcheck := required "If not using the Storm chart's built-in Zookeeper (i.e. `.Values.zookeeper.enabled: false`), `.Values.zookeeper.servers` is required" .Values.zookeeper.servers -}}
-{{- range $server := .Values.zookeeper.servers }}
-{{ printf "- %s" . | indent 6 }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- $servers = .Values.zookeeper.servers -}}
+{{- end -}}
+{{- dict "servers" $servers | toJson -}}
+{{- end -}}
 
-{{- define "storm.nimbus.zookeeper.initContainers" -}}
-{{- $zk_servers := ternary (list (include "storm.zookeeper.fullname" $)) .Values.zookeeper.servers .Values.zookeeper.enabled }}
-{{- range $index, $server := $zk_servers }}
-{{ printf "- name: init-zookeeper-%d" $index | indent 6 }}
-{{ printf "image: %s:%s" $.Values.zookeeper.image.repository $.Values.zookeeper.image.tag | indent 8 }}
-{{ printf "command: ['sh', '-c', 'until zkCli.sh -server %s:%s ls /; do echo waiting for %s; sleep 10; done']" $server (include "storm.zookeeper.client.port" $) $server | indent 8 }}
-{{- end }}
-{{- end }}
-
-{{- define "storm.configmap.data.yaml" }}
-    ########### These MUST be filled in for a storm configuration
-    storm.zookeeper.servers: {{ include "storm.zookeeper.configmap.servers" . }}
-    storm.zookeeper.port: {{ template "storm.zookeeper.client.port" . }}
-    nimbus.seeds: [{{ include "storm.nimbus.fullname" . }}]
-    nimbus.thrift.port: {{ .Values.nimbus.service.port }}
-    storm.log4j2.conf.dir: "/log4j2"
-{{- end }}
+{{- define "storm.nimbus.initCommand" -}}
+{{- $servers := get ((include "storm.zookeeper.config" .) | fromJson) "servers" -}}
+{{- $checks := list -}}
+{{- range $server := $servers -}}
+{{- $checks = append $checks (printf "zkCli.sh -server %s:%s ls /" $server (include "storm.zookeeper.port" $)) -}}
+{{- end -}}
+{{- $checkCommand := join " || " $checks -}}
+{{- printf "until %s; do echo waiting for %v; sleep 10; done" $checkCommand $servers -}}
+{{- end -}}

--- a/src/storm/templates/configmap.yaml
+++ b/src/storm/templates/configmap.yaml
@@ -1,31 +1,27 @@
+{{- $servers := get ((include "storm.zookeeper.config" .) | fromJson) "servers" -}}
+{{- range $name := tuple "nimbus" "supervisor" "ui" }}
+{{- $fullname := include (print "storm." $name ".fullname") $ -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "storm.nimbus.fullname" . }}
+  name: {{ $fullname }}
   labels:
-    chart: {{ template "storm.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    chart: {{ template "storm.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
 data:
   storm.yaml: |-
-    {{- include "storm.configmap.data.yaml" . }}
-    storm.local.hostname: {{ template "storm.nimbus.fullname" . }}
+    storm.zookeeper.servers:
+{{ $servers | toYaml | indent 6 }}
+    storm.zookeeper.port: {{ include "storm.zookeeper.port" $ }}
+    nimbus.seeds:
+      - {{ include "storm.nimbus.fullname" $ }}
+    nimbus.thrift.port: {{ $.Values.nimbus.service.port }}
+    storm.log4j2.conf.dir: /log4j2
+    storm.local.hostname: {{ $fullname }}
 
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "storm.supervisor.fullname" . }}
-  labels:
-    chart: {{ template "storm.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-data:
-  storm.yaml: |-
-    {{- include "storm.configmap.data.yaml" . }}
-    storm.local.hostname: {{ template "storm.supervisor.fullname" . }}
-
----
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,17 +36,3 @@ data:
   {{ . }}: |-
 {{ $files.Get . | indent 4 }}
   {{- end }}
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "storm.ui.fullname" . }}
-  labels:
-    chart: {{ template "storm.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-data:
-  storm.yaml: |-
-    {{- include "storm.configmap.data.yaml" . }} 
-    storm.local.hostname: {{ template "storm.ui.fullname" . }}

--- a/src/storm/templates/nimbus-deployment.yaml
+++ b/src/storm/templates/nimbus-deployment.yaml
@@ -21,8 +21,11 @@ spec:
         app: {{ template "storm.nimbus.name" . }}
         release: {{ .Release.Name }}
     spec:
-      initContainers:
-      {{- template "storm.nimbus.zookeeper.initContainers" . }}
+      initContainers: 
+      - name: init-zookeeper
+        image: "{{ .Values.zookeeper.image.repository }}:{{ .Values.zookeeper.image.tag }}"
+        imagePullPolicy: {{ .Values.zookeeper.image.pullPolicy }}
+        command: ['sh', '-c', '{{ template "storm.nimbus.initCommand" . }}']
       containers:
       - name: {{ .Values.nimbus.service.name }}
         image: "{{ .Values.nimbus.image.repository }}:{{ .Values.nimbus.image.tag }}"

--- a/src/storm/values.yaml
+++ b/src/storm/values.yaml
@@ -53,7 +53,7 @@ ui:
 
 zookeeper:
   enabled: true
-  replicaCount: 3
+  replicaCount: 1
   # if using an external zookeeper, you need to set the server names below
   #servers:
   #  - example.external.zookeeper1

--- a/src/storm/values.yaml
+++ b/src/storm/values.yaml
@@ -54,16 +54,10 @@ ui:
 zookeeper:
   enabled: true
   replicaCount: 3
-  servers:
+  # if using an external zookeeper, you need to set the server names below
+  #servers:
   #  - example.external.zookeeper1
   #  - example.external.zookeeper2
-  service:
-    ports:
-      client:
-        port: 2181
-  # TODO: fix upstream zookeeper chart before port is truly configurable
-  # ports:
-  #   client:
-  #     containerPort: 2181
-  # env:
-  #   ZOO_PORT: 2181 
+  #  - example.external.zookeeper3
+  # external server port
+  #port: 2181


### PR DESCRIPTION
This PR brings various improvements to the storm chart changes from PR #23.

- port forward to the ui service directly in the storm chart notes
- external zookeeper port can be configured through zookeeper.port instead of zookeeper.service.ports.client.port
- all 3 storm configmaps are now generated through a loop
- the list of zookeeper servers is defined only once in _helpers.tpl
- the nimbus init container succeeds when just one of the zookeeper servers is ready instead of waiting for all of them to be ready
- add comments to values.yaml about using external zookeeper servers
- change the default amount of built-in zookeeper replicas to 1

Once merged, we should bump the chart and version and generate the tarball and index in PR #23.

Another improvement that we should make in a subsequent version is to use [bitnami/zookeeper:6.0.0](https://artifacthub.io/packages/helm/bitnami/zookeeper/6.0.0) as incubator/zookeeper has been deprecated.
I tested it successfully as an external zookeeper, and the only change needed to make it work as our built-in chart is to reference `.Values.zookeeper.service.port` instead of `.Values.zookeeper.service.ports.client.port` (sanity finally!)