### PR TITLE
added option to dynamically change worker.childopts in configmap

### DIFF
--- a/src/storm/Chart.yaml
+++ b/src/storm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 1.2.3
-version: 1.0.11
+version: 1.0.12
 description: Apache Storm is a free and open source distributed realtime computation
   system.
 home: http://storm.apache.org/

--- a/src/storm/templates/configmap.yaml
+++ b/src/storm/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
     supervisor.childopts: {{ $.Values.supervisor.childopts }}
     supervisor.worker.heap.memory.mb: {{ $.Values.supervisor.worker.heap_memory_mb }}
     ui.childopts: {{ $.Values.ui.childopts }}
+    worker.childopts: {{ $.Values.worker.childopts }}
 ---
 {{- end }}
 apiVersion: v1

--- a/src/storm/values.yaml
+++ b/src/storm/values.yaml
@@ -83,3 +83,6 @@ zookeeper:
   #  - "example.external.zookeeper3"
   # # external server port
   # port: 2181
+
+worker:
+  childopts: "-Xmx%HEAP-MEM%m -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"


### PR DESCRIPTION
Default worker.childopts value in this PR is for java 8, but has to be modified when using storm 2.2.0 and java 11.