### PR TITLE
Mitigate log4j vulnerability

### DIFF
--- a/src/storm/cluster.xml
+++ b/src/storm/cluster.xml
@@ -18,7 +18,7 @@
 
 <configuration monitorInterval="60" shutdownHook="disable">
 <properties>
-    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %.-5000msg%n</property>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %.-5000msg{nolookups}%n</property>
 </properties>
 <appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">

--- a/src/storm/worker.xml
+++ b/src/storm/worker.xml
@@ -20,7 +20,7 @@
 <properties>
     <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %.-5000msg{nolookups}%n</property>
     <property name="patternNoTime">%msg{nolookups}%n</property>
-    <property name="patternMetrics">%d %-8r %m%n</property>
+    <property name="patternMetrics">%d %-8r %m{nolookups}%n</property>
 </properties>
 <appenders>
     <RollingFile name="A1"

--- a/src/storm/worker.xml
+++ b/src/storm/worker.xml
@@ -19,7 +19,7 @@
 <configuration monitorInterval="60" shutdownHook="disable">
 <properties>
     <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %.-5000msg{nolookups}%n</property>
-    <property name="patternNoTime">%msg%n</property>
+    <property name="patternNoTime">%msg{nolookups}%n</property>
     <property name="patternMetrics">%d %-8r %m%n</property>
 </properties>
 <appenders>

--- a/src/storm/worker.xml
+++ b/src/storm/worker.xml
@@ -18,7 +18,7 @@
 
 <configuration monitorInterval="60" shutdownHook="disable">
 <properties>
-    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %.-5000msg%n</property>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %.-5000msg{nolookups}%n</property>
     <property name="patternNoTime">%msg%n</property>
     <property name="patternMetrics">%d %-8r %m%n</property>
 </properties>


### PR DESCRIPTION
Resolves: #61 
Based on https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832 this mitigation is sufficient for log4j releases >= 2.7 and <= 2.14.1.
Storm 2.3.0 is using 2.11.2