### PR TITLE
GROSS-434: Enable armada-operator to publish charts and move armada repo

### DIFF
--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -48,7 +48,7 @@
         {
           "name": "armada-operator",
           "source": "charts/armada-operator",
-          "destination": "armadaproject"
+          "destination": "armada"
         }
       ]
     },
@@ -65,7 +65,7 @@
         {
           "name": "armada",
           "source": "deployment/armada",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -74,7 +74,7 @@
         {
           "name": "armada-bundle",
           "source": "deployment/bundle",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -83,7 +83,7 @@
         {
           "name": "armada-binoculars",
           "source": "deployment/binoculars",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -92,7 +92,7 @@
         {
           "name": "armada-event-ingester",
           "source": "deployment/event-ingester",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -101,7 +101,7 @@
         {
           "name": "armada-executor",
           "source": "deployment/executor",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -110,7 +110,7 @@
         {
           "name": "armada-executor-cluster-monitoring",
           "source": "deployment/executor-cluster-monitoring",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -119,7 +119,25 @@
         {
           "name": "armada-jobservice",
           "source": "deployment/jobservice",
-          "destination": "armadaproject",
+          "destination": "armada",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-lookout",
+          "source": "deployment/lookout",
+          "destination": "armada",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-lookout-v2",
+          "source": "deployment/lookout-v2",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -128,7 +146,7 @@
         {
           "name": "armada-lookout-migration",
           "source": "deployment/lookout-migration",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -137,7 +155,7 @@
         {
           "name": "armada-lookout-migration-v2",
           "source": "deployment/lookout-migration-v2",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -146,7 +164,7 @@
         {
           "name": "armada-lookout-ingester",
           "source": "deployment/lookout-ingester",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -155,7 +173,7 @@
         {
           "name": "armada-lookout-ingester-v2",
           "source": "deployment/lookout-ingester-v2",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -164,7 +182,7 @@
         {
           "name": "armada-scheduler-migration",
           "source": "deployment/scheduler-migration",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
@@ -173,7 +191,7 @@
         {
           "name": "armada-scheduler",
           "source": "deployment/scheduler",
-          "destination": "armadaproject",
+          "destination": "armada",
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "armada",
-      "key_fingerprint": "94XvtZCWeQVV8ofBFFM7jhnCiFZ2AnIlRGRaN8Sjrcc=",
+      "key_fingerprint": "4KVTeHmSGX0TnlQPKqX1kvUge40tYDDbSzT4+BooYEI=",
       "refs": [
         {
           "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -127,7 +127,7 @@
       ]
     },
     {
-      "name": "armada-operator",
+      "name": "armadaproject",
       "key_fingerprint": "94XvtZCWeQVV8ofBFFM7jhnCiFZ2AnIlRGRaN8Sjrcc=",
       "refs": [
         {

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -125,6 +125,23 @@
           "destination": "siembol"
         }
       ]
+    },
+    {
+      "name": "armada-operator",
+      "key_fingerprint": "94XvtZCWeQVV8ofBFFM7jhnCiFZ2AnIlRGRaN8Sjrcc=",
+      "refs": [
+        {
+          "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",
+          "type": "regex"
+        }
+      ],
+      "helm_charts": [
+        {
+          "name": "armada-operator",
+          "source": "charts/armada-operator",
+          "destination": "armadaproject"
+        }
+      ]
     }
   ]
 }

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -76,15 +76,6 @@
           }
         },
         {
-          "name": "armada-bundle",
-          "source": "deployment/bundle",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
           "name": "armada-binoculars",
           "source": "deployment/binoculars",
           "destination": "armada",

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -17,99 +17,6 @@
       ]
     },
     {
-      "name": "armada",
-      "key_fingerprint": "4KVTeHmSGX0TnlQPKqX1kvUge40tYDDbSzT4+BooYEI=",
-      "refs": [
-        {
-          "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",
-          "type": "regex"
-        }
-      ],
-      "helm_charts": [
-        {
-          "name": "armada",
-          "source": "deployment/armada",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-lookout",
-          "source": "deployment/lookout",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-executor",
-          "source": "deployment/executor",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-executor-cluster-monitoring",
-          "source": "deployment/executor-cluster-monitoring",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-binoculars",
-          "source": "deployment/binoculars",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-lookout-ingester",
-          "source": "deployment/lookout-ingester",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-lookout-migration",
-          "source": "deployment/lookout-migration",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-jobservice",
-          "source": "deployment/jobservice",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        },
-        {
-          "name": "armada-event-ingester",
-          "source": "deployment/event-ingester",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          }
-        }
-      ]
-    },
-    {
       "name": "siembol",
       "key_fingerprint": "YnF/2TR5qQa/M5CUZRvi/46oGdKxYDCeIxTkq9OOeYA=",
       "refs": [
@@ -125,9 +32,11 @@
           "destination": "siembol"
         }
       ]
-    },
+    }
+  ],
+  "armadaproject": [
     {
-      "name": "armadaproject",
+      "name": "armada-operator",
       "key_fingerprint": "94XvtZCWeQVV8ofBFFM7jhnCiFZ2AnIlRGRaN8Sjrcc=",
       "refs": [
         {
@@ -140,6 +49,135 @@
           "name": "armada-operator",
           "source": "charts/armada-operator",
           "destination": "armadaproject"
+        }
+      ]
+    },
+    {
+      "name": "armada",
+      "key_fingerprint": "94XvtZCWeQVV8ofBFFM7jhnCiFZ2AnIlRGRaN8Sjrcc=",
+      "refs": [
+        {
+          "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",
+          "type": "regex"
+        }
+      ],
+      "helm_charts": [
+        {
+          "name": "armada",
+          "source": "deployment/armada",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-bundle",
+          "source": "deployment/bundle",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-binoculars",
+          "source": "deployment/binoculars",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-event-ingester",
+          "source": "deployment/event-ingester",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-executor",
+          "source": "deployment/executor",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-executor-cluster-monitoring",
+          "source": "deployment/executor-cluster-monitoring",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-jobservice",
+          "source": "deployment/jobservice",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-lookout-migration",
+          "source": "deployment/lookout-migration",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-lookout-migration-v2",
+          "source": "deployment/lookout-migration-v2",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-lookout-ingester",
+          "source": "deployment/lookout-ingester",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-lookout-ingester-v2",
+          "source": "deployment/lookout-ingester-v2",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-scheduler-migration",
+          "source": "deployment/scheduler-migration",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
+        },
+        {
+          "name": "armada-scheduler",
+          "source": "deployment/scheduler",
+          "destination": "armadaproject",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
         }
       ]
     }

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -48,7 +48,11 @@
         {
           "name": "armada-operator",
           "source": "charts/armada-operator",
-          "destination": "armada"
+          "destination": "armada",
+          "use_ref_as_version": {
+            "pattern": "^refs/tags/v",
+            "replacement": ""
+          }
         }
       ]
     },


### PR DESCRIPTION
Following the established practice of publishing charts https://github.com/G-Research/gr-oss/issues/299 we want to add [armadaproject/armada-operator](https://github.com/armadaproject/armada-operator/tree/main) and be able to use this workflow in `armadaproject` org

Pre-requisite:
- Installed GitHub app to the repo
- Access to org secrets

Scope of the change and a few important notes:
- charts will be published to [G-Research/charts - gh-pages](https://github.com/G-Research/charts/tree/gh-pages) branch under folder `armadaproject` (which will be created)
- the `charts/armada-operator/Chart.yaml` file will be overwritten with a tag version. The `appVersion` and `version` will be replaced with the tag (e.g 
  - Published tags must begin with `vX.Y.Z` (semantic versioning), if that's not followed packaging charts wii fail
- In future new charts from `armadaproject` org must be added following same structure of `helm_charts` in `config.json` for all charts of `armadaproject` org
e.g for [armadaproject/armada](https://github.com/armadaproject/armada)
```json
        {
          "name": "armada",  // name which will be used to package the chart (e.g armada-0.0.1.tar.gz)
          "source": "deployment/armada", // location of Chart.yaml in the app repo
          "destination": "armadaproject" // folder in G-Reserach/charts on gh-pages branch where raw tar.gz files will be published and index.yaml updated 
        }
```

@dejanzele please provide a list of other projects if you want to add them now