### PR TITLE
fix node version for publishing charts

### DIFF
--- a/.github/workflows/invoke-push.yaml
+++ b/.github/workflows/invoke-push.yaml
@@ -21,6 +21,9 @@ jobs:
           repository: G-Research/charts
           path: charts
           ref: master
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - run: npm i octokit @octokit/core
       - name: Trigger push workflow
         uses: actions/github-script@v6

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,6 +34,11 @@ jobs:
         with:
           path: self
 
+      - name: Setup Node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
       - name: Validate chart
         uses: actions/github-script@v6
         env:


### PR DESCRIPTION
From failed [workflow](https://github.com/armadaproject/armada-operator/actions/runs/5623930709/job/15239732702#step:4:26) we got info that ubuntu-22.04 has Node 16 by default and we need Node 18 for octokit library per https://github.com/octokit/octokit.js/#fetch-missing

