### PR TITLE
Fix charts publication by updating the authStrategy for fetching the app token

### DIFF
--- a/.github/workflows/invoke-push.yaml
+++ b/.github/workflows/invoke-push.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: npm i octokit @octokit/core
       - name: Trigger push workflow
         uses: actions/github-script@v6
-        env: 
+        env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,7 +35,7 @@ jobs:
           path: self
 
       - name: Validate chart
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}
@@ -58,7 +58,7 @@ jobs:
           path: source
 
       - name: Package charts
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         with:
           script: |
             const helm = require('./self/.github/workflows/scripts/packageChart.js')
@@ -68,7 +68,7 @@ jobs:
         run: npm i octokit fs @octokit/core
 
       - name: Update index and push files
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v6
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,7 +35,7 @@ jobs:
           path: self
 
       - name: Validate chart
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}
@@ -58,17 +58,17 @@ jobs:
           path: source
 
       - name: Package charts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         with:
           script: |
             const helm = require('./self/.github/workflows/scripts/packageChart.js')
             return await helm({ core, glob, exec })
 
       - name: Install packages
-        run: npm i octokit fs @octokit/request @octokit/core
+        run: npm i octokit fs @octokit/core
 
       - name: Update index and push files
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}
@@ -79,8 +79,8 @@ jobs:
 
             const tokenPermissions = { contents: "write" } // required to push files 
             try {
-              const token = await generateToken({ core }, 'G-Research', 'charts', tokenPermissions )
-              return await push({ core, exec, context }, token)
+              const token = await generateToken({ core, fetch }, 'G-Research', 'charts', tokenPermissions )
+              return await push({ core, exec, context, fetch }, token )
             } catch (error) {
               core.notice(`Permission: ${JSON.stringify(tokenPermissions)}`)
               return core.setFailed(`Unable to push ${context.payload.repository.owner.login}/${context.payload.repository.name}, please check token permissions.\n${error}`)

--- a/.github/workflows/scripts/push.js
+++ b/.github/workflows/scripts/push.js
@@ -1,6 +1,10 @@
-module.exports = async ({ core, exec, context }, token) => {
+module.exports = async ({ core, exec, context, fetch }, token) => {
   const { Octokit } = require("@octokit/core")
-  const octokit = new Octokit({ auth: token })
+  const octokit = new Octokit({
+    request: { fetch: fetch },
+    auth: token,
+  });
+
   const checkoutPageDir = "gh-pages"
   const branchName = "gh-pages"
   const helm = {

--- a/.github/workflows/scripts/token.js
+++ b/.github/workflows/scripts/token.js
@@ -1,35 +1,55 @@
-module.exports = async ({ core }, owner, repo, tokenPermissions) => {
-  const { App } = require("octokit")
-  const app = new App({
-    appId: process.env.APP_ID,
-    privateKey: process.env.APP_PRIVATE_KEY,
-  })
+module.exports = async ({ core, fetch }, owner, repo, tokenPermissions) => {
+  const { Octokit } = require("@octokit/core");
+  const { createAppAuth } = require("@octokit/auth-app");
 
-  const permissions = (tokenPermissions === undefined) ? {
-    actions: "read",
-  } : tokenPermissions
+  const permissions = tokenPermissions === undefined
+    ? { actions: "read" }
+    : tokenPermissions;
 
-  for await (const { data: installations } of app.octokit.paginate.iterator(
-    app.octokit.rest.apps.listInstallations
-  )) {
+  try {
+    // Get all installations accessible to the app
+    const octokit = new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId: process.env.APP_ID,
+        privateKey: process.env.APP_PRIVATE_KEY,
+      },
+      request: { fetch: fetch } // Pass the 'fetch' function here as well
+    });
+
+    const { data: installations } = await octokit.request("GET /app/installations");
+
     for (const installation of installations) {
       if (installation.account.login === owner) {
-        const octokit = await app.getInstallationOctokit(installation.id)
+        // Use the app's JWT to authenticate as the app
+        const appOctokit = new Octokit({
+          authStrategy: createAppAuth,
+          auth: {
+            appId: process.env.APP_ID,
+            privateKey: process.env.APP_PRIVATE_KEY,
+            installationId: installation.id,
+          },
+          request: { fetch: fetch }
+        });
+
         try {
+          // Create an installation access token for the app
           // https://docs.github.com/en/rest/reference/apps#create-an-installation-access-token-for-an-app
-          const { data: response } = await octokit.request('POST /app/installations/{installation_id}/access_tokens', {
+          const { data: response } = await appOctokit.request('POST /app/installations/{installation_id}/access_tokens', {
             installation_id: installation.id,
             repositories: [`${repo}`],
             permissions: permissions
-          })
-          core.debug(`Response: ${JSON.stringify(response)}`)
-          return response.token
+          });
+
+          core.debug(`Response: ${JSON.stringify(response)}`);
+          return response.token;
 
         } catch (error) {
-          return core.setFailed(`Unable to generate token for ${owner}/${repo}\nPermission: ${JSON.stringify(permissions)}\n${error}`)
+          return core.setFailed(`Unable to generate token for ${owner}/${repo}\nPermission: ${JSON.stringify(permissions)}\n${error}`);
         }
-
       }
     }
+  } catch (error) {
+    return core.setFailed(`Error retrieving installations for ${owner}/${repo}\n${error}`);
   }
 }

--- a/.github/workflows/scripts/workflow.js
+++ b/.github/workflows/scripts/workflow.js
@@ -1,6 +1,6 @@
-module.exports = async ({ core, context }, token) => {
+module.exports = async ({ core, context, fetch }, token) => {
   const { Octokit } = require("@octokit/core")
-  const octokit = new Octokit({ auth: token })
+  const octokit = new Octokit({ auth: token, request: { fetch: fetch } });
 
   const owner = 'G-Research'
   const repo = 'charts'


### PR DESCRIPTION
By adding `armada-operator` we confirmed that G-Research/charts `.github/workflows/scripts/token.js` script had deprecated function and libraries used to get the token of GitHub App
 
This PR introduces few changes
- adding `createAppAuth` as `authStrategy`
- update `actions/github-script` to `v6.4.1`

Workflow is tested with forked repos and adjusted `config.json` in order to be valid one
- [Invoke-push (armada-operator)](https://github.com/ljubon/armada-operator/actions/runs/5635309036/job/15266136515)
- [Push charts (charts)](https://github.com/ljubon/charts/actions/runs/5635318976/job/15266161544)
- [Verified new files with tag `0.0.6` exist for `armada-operator`](https://github.com/ljubon/charts/tree/gh-pages/armada)

FYI @dejanzele @jgiannuzzi @pavlovic-ivan 