### PR TITLE
Fix publishing charts when workflow is triggered with `workflow_run`

### DIFF
--- a/.github/workflows/invoke-push.yaml
+++ b/.github/workflows/invoke-push.yaml
@@ -2,11 +2,6 @@ name: Invoke Push
 
 on:
   workflow_call:
-    inputs:
-      version:
-        description: 'Used when workflow_call is triggering invoke-push workflow'
-        required: false
-        type: string
     secrets:
       APP_ID:
         description: 'The ID of the GitHub App that can trigger a workflow on this repo'
@@ -32,18 +27,11 @@ jobs:
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          VERSION: ${{ inputs.version }}
         with:
           script: |
             const generateToken = require('./charts/.github/workflows/scripts/token.js')
             const workflow = require('./charts/.github/workflows/scripts/workflow.js')
             const tokenPermissions = { actions: "write" } // required
-
-            let version = process.env.VERSION || context.payload.ref;
-            if (process.env.VERSION) {
-              version = `refs/tags/${version}`;
-            }
-            console.log(`Version: ${version}`);
 
             try {
               const token = await generateToken({ core, fetch }, 'G-Research','charts', tokenPermissions )

--- a/.github/workflows/invoke-push.yaml
+++ b/.github/workflows/invoke-push.yaml
@@ -2,6 +2,11 @@ name: Invoke Push
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: 'Used when workflow_call is triggering invoke-push workflow'
+        required: false
+        type: string
     secrets:
       APP_ID:
         description: 'The ID of the GitHub App that can trigger a workflow on this repo'
@@ -27,14 +32,22 @@ jobs:
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          VERSION: ${{ inputs.version }}
         with:
           script: |
             const generateToken = require('./charts/.github/workflows/scripts/token.js')
             const workflow = require('./charts/.github/workflows/scripts/workflow.js')
             const tokenPermissions = { actions: "write" } // required
+
+            let version = process.env.VERSION || context.payload.ref;
+            if (process.env.VERSION) {
+              version = `refs/tags/${version}`;
+            }
+            console.log(`Version: ${version}`);
+
             try {
               const token = await generateToken({ core, fetch }, 'G-Research','charts', tokenPermissions )
-              return await workflow({ core, context, fetch }, token )
+              return await workflow({ core, context, fetch }, token, version )
             } catch (error) {
               core.notice(`Permission: ${JSON.stringify(tokenPermissions)}`)
               return core.setFailed(`Unable to trigger workflow G-Research/charts, please check token permissions.\n${error}`)

--- a/.github/workflows/invoke-push.yaml
+++ b/.github/workflows/invoke-push.yaml
@@ -32,10 +32,9 @@ jobs:
             const generateToken = require('./charts/.github/workflows/scripts/token.js')
             const workflow = require('./charts/.github/workflows/scripts/workflow.js')
             const tokenPermissions = { actions: "write" } // required
-
             try {
               const token = await generateToken({ core, fetch }, 'G-Research','charts', tokenPermissions )
-              return await workflow({ core, context, fetch }, token, version )
+              return await workflow({ core, context, fetch }, token )
             } catch (error) {
               core.notice(`Permission: ${JSON.stringify(tokenPermissions)}`)
               return core.setFailed(`Unable to trigger workflow G-Research/charts, please check token permissions.\n${error}`)

--- a/.github/workflows/scripts/workflow.js
+++ b/.github/workflows/scripts/workflow.js
@@ -1,4 +1,4 @@
-module.exports = async ({ core, context, fetch }, token, version) => {
+module.exports = async ({ core, context, fetch }, token) => {
   const { Octokit } = require("@octokit/core")
   const octokit = new Octokit({ auth: token, request: { fetch: fetch } });
 
@@ -6,6 +6,11 @@ module.exports = async ({ core, context, fetch }, token, version) => {
   const repo = 'charts'
   const ref = 'master'
   const workflow_name = 'Push'
+  let version = context.payload.workflow_run.head_branch || context.payload.ref
+  if (context.payload.workflow_run.head_branch) {
+    version = `refs/tags/${version}`;
+  }
+  core.notice(`Version: ${version}`)
 
   const { data: repo_workflows } = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows', {
     owner: owner,

--- a/.github/workflows/scripts/workflow.js
+++ b/.github/workflows/scripts/workflow.js
@@ -1,4 +1,4 @@
-module.exports = async ({ core, context, fetch }, token) => {
+module.exports = async ({ core, context, fetch }, token, version) => {
   const { Octokit } = require("@octokit/core")
   const octokit = new Octokit({ auth: token, request: { fetch: fetch } });
 
@@ -31,7 +31,7 @@ module.exports = async ({ core, context, fetch }, token) => {
       inputs: {
         owner: context.payload.repository.owner.login,
         repo: context.payload.repository.name,
-        ref: context.payload.ref
+        ref: version
       },
     })
 

--- a/.github/workflows/scripts/workflow.js
+++ b/.github/workflows/scripts/workflow.js
@@ -6,9 +6,9 @@ module.exports = async ({ core, context, fetch }, token) => {
   const repo = 'charts'
   const ref = 'master'
   const workflow_name = 'Push'
-  let version = context.payload.workflow_run.head_branch || context.payload.ref
-  if (context.payload.workflow_run.head_branch) {
-    version = `refs/tags/${version}`;
+  let version = context.payload.ref
+  if (context.payload.workflow_run !== undefined) {
+    version = `refs/tags/${context.payload.workflow_run.head_branch}`
   }
   core.notice(`Version: ${version}`)
 


### PR DESCRIPTION
We need to allow `charts` to receive `version` as inputs which should be used if user/client want's to set the tag or version of the charts