### PR TITLE
CI: Helm charts unit tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -24,6 +24,10 @@ on:
         required: true
         type: string
 
+env:
+  # Used for charts unit testing in packageChart.js
+  HELM_UNITTEST_VERSION: 0.4.1
+
 jobs:
   push:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,6 +34,16 @@ jobs:
         with:
           path: self
 
+      - name: Storm - unit tests
+        env:
+          HELM_UNITTESTS_VERSION: 0.3.5
+          HELM_UNITTESTS_PLUGIN: https://github.com/helm-unittest/helm-unittest
+        working-directory: self/storm
+        shell: bash
+        run: |
+          helm plugin install ${HELM_UNITTESTS_PLUGIN} --version ${HELM_UNITTESTS_VERSION} > /dev/null
+          helm unittest . -o storm/tests/results/test-output.xml -t junit
+
       - name: Validate chart
         uses: actions/github-script@v6
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,16 +34,6 @@ jobs:
         with:
           path: self
 
-      - name: Storm - unit tests
-        env:
-          HELM_UNITTESTS_VERSION: 0.3.5
-          HELM_UNITTESTS_PLUGIN: https://github.com/helm-unittest/helm-unittest
-        working-directory: self/storm
-        shell: bash
-        run: |
-          helm plugin install ${HELM_UNITTESTS_PLUGIN} --version ${HELM_UNITTESTS_VERSION} > /dev/null
-          helm unittest . -o storm/tests/results/test-output.xml -t junit
-
       - name: Validate chart
         uses: actions/github-script@v6
         env:

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -12,7 +12,8 @@
         {
           "name": "storm",
           "source": "storm",
-          "destination": "storm"
+          "destination": "storm",
+          "tests": true
         }
       ]
     },
@@ -29,7 +30,8 @@
         {
           "name": "siembol",
           "source": "deployment/helm-k8s",
-          "destination": "siembol"
+          "destination": "siembol",
+          "tests": false
         }
       ]
     }
@@ -52,7 +54,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         }
       ]
     },
@@ -73,7 +76,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-binoculars",
@@ -82,7 +86,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-event-ingester",
@@ -91,7 +96,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-executor",
@@ -100,7 +106,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-executor-cluster-monitoring",
@@ -109,7 +116,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-jobservice",
@@ -118,7 +126,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-lookout-v2",
@@ -127,7 +136,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-lookout-migration-v2",
@@ -136,7 +146,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-lookout-ingester-v2",
@@ -145,7 +156,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-scheduler-migration",
@@ -154,7 +166,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         },
         {
           "name": "armada-scheduler",
@@ -163,7 +176,8 @@
           "use_ref_as_version": {
             "pattern": "^refs/tags/v",
             "replacement": ""
-          }
+          },
+          "tests": false
         }
       ]
     }

--- a/.github/workflows/scripts/packageChart.js
+++ b/.github/workflows/scripts/packageChart.js
@@ -45,6 +45,17 @@ module.exports = async ({ core, exec }) => {
         }
       }
 
+      // Run Helm unit tests if enabled
+      if (chart.tests) {
+        try {
+          core.notice(`Packaging the ${chart.name} chart`)
+          await exec.exec('helm', ['plugin', 'install', '"https://github.com/helm-unittest/helm-unittest"', '--version', '0.4.1'], { cwd: `${checkoutSourceDir}/${chart.source}` })
+          await exec.exec('helm', ['unittest', '.', '-o', 'test-output.xml', '-t', 'junit'], { cwd: `${checkoutSourceDir}/${chart.source}` })
+        } catch (error) {
+          return core.setFailed(`Helm unit tests for chart ${chart.name} failed\nError: ${error}`)
+        }
+      }
+
       core.notice(`Packaging the ${chart.name} chart`)
       await exec.exec('helm', ['package', `${checkoutSourceDir}/${chart.source}`, '-d', `${checkoutPageDir}/${chart.destination}`])
       await exec.exec('git', ['add', `${chart.destination}`], { cwd: checkoutPageDir })

--- a/.github/workflows/scripts/packageChart.js
+++ b/.github/workflows/scripts/packageChart.js
@@ -49,7 +49,7 @@ module.exports = async ({ core, exec }) => {
       if (chart.tests) {
         try {
           core.notice(`Packaging the ${chart.name} chart`)
-          await exec.exec('helm', ['plugin', 'install', '"https://github.com/helm-unittest/helm-unittest"', '--version', '0.4.1'], { cwd: `${checkoutSourceDir}/${chart.source}` })
+          await exec.exec('helm', ['plugin', 'install', '"https://github.com/helm-unittest/helm-unittest"', '--version', `${process.env.HELM_UNITTEST_VERSION}`], { cwd: `${checkoutSourceDir}/${chart.source}` })
           await exec.exec('helm', ['unittest', '.', '-o', 'test-output.xml', '-t', 'junit'], { cwd: `${checkoutSourceDir}/${chart.source}` })
         } catch (error) {
           return core.setFailed(`Helm unit tests for chart ${chart.name} failed\nError: ${error}`)

--- a/storm/templates/configmap.yaml
+++ b/storm/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     chart: {{ template "storm.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
+  namespace: {{ template "storm.namespace" . }}
 data:
   storm.yaml: |-
     storm.zookeeper.servers:

--- a/storm/templates/nimbus-statefulset.yaml
+++ b/storm/templates/nimbus-statefulset.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ if .Values.mockChecksum }}{{ .Values.mockChecksum }}{{ else }}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{{ end }}
       labels:
         app: {{ template "storm.nimbus.name" . }}
         release: {{ .Release.Name }}

--- a/storm/templates/ui-deployment.yaml
+++ b/storm/templates/ui-deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ if .Values.mockChecksum }}{{ .Values.mockChecksum }}{{ else }}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{{ end }}
       labels:
         app: {{ template "storm.ui.name" . }}
         release: {{ .Release.Name }}

--- a/storm/tests/configmap_test.yaml
+++ b/storm/tests/configmap_test.yaml
@@ -1,0 +1,16 @@
+---
+suite: ConfigMap template
+templates:
+  - configmap.yaml
+values:
+  - ../values.yaml
+release:
+  name: storm
+tests:
+  - it: ConfigMap verification
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+

--- a/storm/tests/deployment_test.yaml
+++ b/storm/tests/deployment_test.yaml
@@ -1,0 +1,18 @@
+---
+suite: Deployment template
+templates:
+  - ui-deployment.yaml
+  - supervisor-deployment.yaml
+values:
+  - ../values.yaml
+release:
+  name: storm
+tests:
+  - it: Deployment verification
+    set:
+      mockChecksum: "mocked-checksum-value"
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1

--- a/storm/tests/service_test.yaml
+++ b/storm/tests/service_test.yaml
@@ -1,0 +1,18 @@
+---
+suite: Service template
+templates:
+  - ui-service.yaml
+  - supervisor-service.yaml
+  - nimbus-service.yaml
+values:
+  - ../values.yaml
+release:
+  name: storm
+tests:
+  - it: Service verification
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+

--- a/storm/tests/statefulset_test.yaml
+++ b/storm/tests/statefulset_test.yaml
@@ -1,0 +1,18 @@
+---
+suite: StatefulSet template
+templates:
+  - nimbus-statefulset.yaml
+values:
+  - ../values.yaml
+release:
+  name: storm
+tests:
+  - it: StatefulSet verification
+    set:
+      mockChecksum: "mocked-checksum-value"
+    asserts:
+      - notFailedTemplate: {}
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+


### PR DESCRIPTION
Goal of this PR is to introduce `unittests` plugin which will help us test our charts before publishing them
Helm unit tests will run if we enable that option in `.github/workflows/scripts/config.json` with setting `"tests": true` or `false`

```json
{
// removed for brevity 
    {
      "name": "charts",
      "refs": [
        {
          "type": "branch",
          "ref": "master"
        }
      ],
      "helm_charts": [
        {
          "name": "storm",
          "source": "storm",
          "destination": "storm",
          "tests": true
        }
      ]
    },

```

[Example ](https://github.com/ljubon/charts/actions/runs/7481259178/job/20362485060#step:6:81)run for `storm` chart

Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/421

