### PR TITLE
add fastrackml to charts

### DIFF
--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -34,6 +34,24 @@
           "tests": false
         }
       ]
+    },
+    {
+      "name": "fasttrackml",
+      "key_fingerprint": "Da10MkM0RnFLWCcBbZ8ij+lYntgMDGSBdhljq+Oz5HY=",
+      "refs": [
+        {
+          "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",
+          "type": "regex"
+        }
+      ],
+      "helm_charts": [
+        {
+          "name": "fasttrackml",
+          "source": "helm/fasttrackml",
+          "destination": "fasttrackml",
+          "tests": false
+        }
+      ]
     }
   ],
   "armadaproject": [


### PR DESCRIPTION
Goal of this PR is to add `fasttrackml` charts to G-Research Helm Charts repo

Required merging https://github.com/G-Research/fasttrackml/pull/845
