### PR TITLE
Fix for ES Module Import Error in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/scripts/push.js
+++ b/.github/workflows/scripts/push.js
@@ -1,5 +1,5 @@
 module.exports = async ({ core, exec, context, fetch }, token) => {
-  const { Octokit } = require("@octokit/core")
+  const { Octokit } = await import("@octokit/core");
   const octokit = new Octokit({
     request: { fetch: fetch },
     auth: token,

--- a/.github/workflows/scripts/token.js
+++ b/.github/workflows/scripts/token.js
@@ -1,6 +1,6 @@
 module.exports = async ({ core, fetch }, owner, repo, tokenPermissions) => {
-  const { Octokit } = require("@octokit/core");
-  const { createAppAuth } = require("@octokit/auth-app");
+  const { Octokit } = await import("@octokit/core");
+  const { createAppAuth } = await import("@octokit/auth-app");
 
   const permissions = tokenPermissions === undefined
     ? { actions: "read" }

--- a/.github/workflows/scripts/workflow.js
+++ b/.github/workflows/scripts/workflow.js
@@ -1,5 +1,5 @@
 module.exports = async ({ core, context, fetch }, token) => {
-  const { Octokit } = require("@octokit/core")
+  const { Octokit } = await import("@octokit/core");
   const octokit = new Octokit({ auth: token, request: { fetch: fetch } });
 
   const owner = 'G-Research'


### PR DESCRIPTION
Problem was generating token for calling workflow push.yaml from G-Research/charts
At some point, @octokit/core and @octokit/auth-appmoved from CommonJS modules to ES Modules, which required using import instead of require current code is not compatible with that

Issue found during publishing armada [here](https://github.com/armadaproject/armada/actions/runs/9016635729/job/24774779909)

Resolves: https://github.com/G-Research/gr-oss/issues/683

### Testing:

 - Example push from gr-oss-devops/armada: https://github.com/gr-oss-devops/armada/actions/runs/9018467522

 - Pushing charts on gr-oss-devops/charts: https://github.com/gr-oss-devops/charts/actions/runs/9018665244

 - Result is published charts to gh-pages on gr-oss-devops/charts - https://github.com/gr-oss-devops/charts/commit/1ea2eb5f642fc64caf5b336aaef2f7656d73a605