### PR TITLE
add yunikorn-history-server charts

### DIFF
--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -55,7 +55,7 @@
     },
     {
       "name": "yunikorn-history-server",
-      "key_fingerprint": "XXXX",
+      "key_fingerprint": "wrNW9GyqMpq4pv1EgXrgwYPweqsHJo2hRzqOMiBYjS8=",
       "refs": [
         {
           "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -52,6 +52,24 @@
           "tests": false
         }
       ]
+    },
+    {
+      "name": "yunikorn-history-server",
+      "key_fingerprint": "XXXX",
+      "refs": [
+        {
+          "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",
+          "type": "regex"
+        }
+      ],
+      "helm_charts": [
+        {
+          "name": "yunikorn-history-server",
+          "source": "charts/",
+          "destination": "yunikorn-history-server",
+          "tests": false
+        }
+      ]
     }
   ],
   "armadaproject": [


### PR DESCRIPTION
TODO:
- [ ] When GitHub app is created for YHS add the values to the change in this PR

Goal of this PR is to allow YHS to publish it's chart to official G-Research repository

YHS release PR to publish change: https://github.com/gr-oss-devops/yunikorn-history-server/pull/8