### PR TITLE
Add nodeSelector, serviceAccountName and tolerations for supervisor deployment

### DIFF
--- a/storm/README.md
+++ b/storm/README.md
@@ -49,7 +49,9 @@ The following table lists the configurable parameters of the Storm chart and the
 | `supervisor.image.repository`          | Container image name           | storm               |
 | `supervisor.image.tag`                 | Container image version        | 2.4.0               |
 | `supervisor.image.pullPolicy`          | The default pull policy        | IfNotPresent        |
+| `supervisor.nodeSelector`              | The nodeSelector               | {}                  |
 | `supervisor.serviceAccountName`        | The serviceAccountName         | ""                  |
+| `supervisor.tolerations`               | The tolerations                | []                  |
 | `supervisor.service.name`              | Service Name                   | supervisor          |
 | `supervisor.service.type`              | Service Type                   | ClusterIP           |
 | `supervisor.slots`                     | Slots/Workers (one port each)  | 4                   |

--- a/storm/README.md
+++ b/storm/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the Storm chart and the
 | `supervisor.image.repository`          | Container image name           | storm               |
 | `supervisor.image.tag`                 | Container image version        | 2.4.0               |
 | `supervisor.image.pullPolicy`          | The default pull policy        | IfNotPresent        |
-| `supervisor.serviceAccountName`        | The serviceAccountName                                   | ""           |
+| `supervisor.serviceAccountName`        | The serviceAccountName         | ""                  |
 | `supervisor.service.name`              | Service Name                   | supervisor          |
 | `supervisor.service.type`              | Service Type                   | ClusterIP           |
 | `supervisor.slots`                     | Slots/Workers (one port each)  | 4                   |

--- a/storm/README.md
+++ b/storm/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Storm chart and the
 | Parameter                              | Description                    | Default             |
 | ---------------------------------      | ---------------------------    | ------------------- |
 | `supervisor.replicaCount`              | Number of replicas             | 2                   |
+| `supervisor.extraLabels`               | Extra labels for Deployment    | {}                  |
 | `supervisor.image.repository`          | Container image name           | storm               |
 | `supervisor.image.tag`                 | Container image version        | 2.4.0               |
 | `supervisor.image.pullPolicy`          | The default pull policy        | IfNotPresent        |

--- a/storm/README.md
+++ b/storm/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Storm chart and the
 | `supervisor.image.repository`          | Container image name           | storm               |
 | `supervisor.image.tag`                 | Container image version        | 2.4.0               |
 | `supervisor.image.pullPolicy`          | The default pull policy        | IfNotPresent        |
+| `supervisor.serviceAccountName`        | The serviceAccountName                                   | ""           |
 | `supervisor.service.name`              | Service Name                   | supervisor          |
 | `supervisor.service.type`              | Service Type                   | ClusterIP           |
 | `supervisor.slots`                     | Slots/Workers (one port each)  | 4                   |

--- a/storm/templates/supervisor-deployment.yaml
+++ b/storm/templates/supervisor-deployment.yaml
@@ -80,6 +80,14 @@ spec:
       {{- if .Values.supervisor.serviceAccountName }}
       serviceAccountName: {{ .Values.supervisor.serviceAccountName }}
       {{- end }}
+      {{- if .Values.supervisor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.supervisor.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.supervisor.tolerations }}
+      tolerations:
+        {{- toYaml .Values.supervisor.tolerations | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.jmx.enabled }}
       - name: jmx-configmap

--- a/storm/templates/supervisor-deployment.yaml
+++ b/storm/templates/supervisor-deployment.yaml
@@ -77,6 +77,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.security.userid }}
         fsGroup: {{ .Values.security.groupid }}
+      {{- if .Values.supervisor.serviceAccountName }}
+      serviceAccountName: {{ .Values.supervisor.serviceAccountName }}
+      {{- end }}
       volumes:
       {{- if .Values.jmx.enabled }}
       - name: jmx-configmap

--- a/storm/templates/supervisor-deployment.yaml
+++ b/storm/templates/supervisor-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "storm.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.supervisor.extraLabels }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
   namespace: {{ template "storm.namespace" . }}
 spec:
   replicas: {{ .Values.supervisor.replicaCount }}


### PR DESCRIPTION
This PR adds `nodeSelector`, `serviceAccountName` and `tolerations` to the supervisor deployment.