### PR TITLE
Remove -v2 suffixed lookout helm charts

### DIFF
--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -155,7 +155,6 @@
           },
           "tests": false
         },
-
         {
           "name": "armada-lookout",
           "source": "deployment/lookout",

--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -155,36 +155,7 @@
           },
           "tests": false
         },
-        {
-          "name": "armada-lookout-v2",
-          "source": "deployment/lookout-v2",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          },
-          "tests": false
-        },
-        {
-          "name": "armada-lookout-migration-v2",
-          "source": "deployment/lookout-migration-v2",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          },
-          "tests": false
-        },
-        {
-          "name": "armada-lookout-ingester-v2",
-          "source": "deployment/lookout-ingester-v2",
-          "destination": "armada",
-          "use_ref_as_version": {
-            "pattern": "^refs/tags/v",
-            "replacement": ""
-          },
-          "tests": false
-        },
+
         {
           "name": "armada-lookout",
           "source": "deployment/lookout",


### PR DESCRIPTION
These have already been removed from the Armada repo.