### PR TITLE
ci: bump node20 actions for node24 cutover

### DIFF
--- a/.github/workflows/invoke-push.yaml
+++ b/.github/workflows/invoke-push.yaml
@@ -16,14 +16,14 @@ jobs:
     environment: invoke-push
     steps:
       - name: Checkout self
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: G-Research/charts
           path: charts
           ref: master
       - run: npm i octokit @octokit/core
       - name: Trigger push workflow
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.9'
           check-latest: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,12 +34,12 @@ jobs:
     environment: push
     steps:
       - name: Checkout self
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: self
 
       - name: Validate chart
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}
@@ -49,20 +49,20 @@ jobs:
             return await config({ core, context })
 
       - name: Checkout gh-pages
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Checkout ${{ env.OWNER }}/${{ env.REPO }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: ${{ env.OWNER }}/${{ env.REPO }}
           ref: ${{ env.REF }}
           path: source
 
       - name: Package charts
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const helm = require('./self/.github/workflows/scripts/packageChart.js')
@@ -72,7 +72,7 @@ jobs:
         run: npm i octokit fs @octokit/core
 
       - name: Update index and push files
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}


### PR DESCRIPTION
GitHub forces `using: node20` JS actions to Node 24 on 2026-06-02. Bumping affected pins across `lint-test.yaml`, `push.yaml`, and `invoke-push.yaml` to the lowest tag that declares `using: node24`.

- `actions/checkout`: v4 → v5.0.1
- `actions/github-script`: v7 → v8.0.0
- `actions/setup-python`: v5 → v6.2.0
- `azure/setup-helm`: v4 → v5.0.0